### PR TITLE
refactor(script): extract parser function in its own file for testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -351,6 +351,18 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
+    "dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+      "dev": true
+    },
+    "diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true
+    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -384,6 +396,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true
     },
     "execa": {
       "version": "1.0.0",
@@ -583,6 +601,12 @@
         "universalify": "^2.0.0"
       }
     },
+    "kleur": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+      "dev": true
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -609,6 +633,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+    },
+    "mri": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
+      "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -727,6 +757,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "sade": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
+      "integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
+      "dev": true,
+      "requires": {
+        "mri": "^1.1.0"
+      }
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -818,6 +857,12 @@
         "is-number": "^7.0.0"
       }
     },
+    "totalist": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
+      "integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
@@ -840,6 +885,19 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+    },
+    "uvu": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.1.tgz",
+      "integrity": "sha512-JGxttnOGDFs77FaZ0yMUHIzczzQ5R1IlDeNW6Wymw6gAscwMdAffVOP6TlxLIfReZyK8tahoGwWZaTCJzNFDkg==",
+      "dev": true,
+      "requires": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3",
+        "totalist": "^2.0.0"
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "description": "Add cache parameter to GitHub Actions using setup-node",
   "scripts": {
     "start": "node cli.js",
-    "test": "node script.js"
+    "test": "uvu tests"
   },
   "repository": "https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action",
   "keywords": [
@@ -23,7 +23,10 @@
     "prettier": "^2.3.2",
     "yaml": "^2.0.0-6"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "esm": "^3.2.25",
+    "uvu": "^0.5.1"
+  },
   "release": {
     "branches": [
       "main"

--- a/script.js
+++ b/script.js
@@ -1,10 +1,7 @@
 // @ts-check
 
 import { composeCreatePullRequest } from "octokit-plugin-create-pull-request";
-import prettier from "prettier";
-import YAML from "yaml";
-
-const { parseDocument } = YAML;
+import { getAddCacheToSetupNodeFunction } from "./utils/yaml-parser";
 
 const BRANCH_NAME = "add-cache-to-node-workflows";
 const PATH = ".github/workflows";
@@ -62,45 +59,7 @@ export async function script(octokit, repository, { cache = "npm" }) {
   const filesToEdit = {};
 
   workflowFiles.forEach((element) => {
-    filesToEdit[element.path] = ({ content, encoding }) => {
-      const yamlDocument = parseDocument(
-        Buffer.from(content, encoding).toString("utf-8")
-      );
-      const jobs = yamlDocument.get("jobs");
-      let cacheAdded = false;
-
-      for (const { value: job } of jobs.items) {
-        const steps = job.get("steps");
-        for (const step of steps.items) {
-          const stepUses = step.get("uses");
-          const stepWith = step.get("with");
-
-          if (
-            stepUses &&
-            stepUses.includes("actions/setup-node") &&
-            (!stepWith || !stepWith.get("cache"))
-          ) {
-            if (!stepWith) {
-              step.set("with", { cache });
-            } else {
-              stepWith.set("cache", cache);
-            }
-
-            if (stepUses === "actions/setup-node@v1") {
-              step.set("uses", "actions/setup-node@v2");
-            }
-
-            cacheAdded = true;
-          }
-        }
-      }
-
-      return cacheAdded
-        ? prettier.format(yamlDocument.toString(), {
-            parser: "yaml",
-          })
-        : null;
-    };
+    filesToEdit[element.path] = getAddCacheToSetupNodeFunction(cache)
   });
 
   const prCreated = await composeCreatePullRequest(octokit, {

--- a/tests/utils/github-action-fixtures/already-has-cache/example1/actual.yml
+++ b/tests/utils/github-action-fixtures/already-has-cache/example1/actual.yml
@@ -1,0 +1,23 @@
+name: Build
+on:
+  push:
+    branches-ignore:
+      - main
+      - staging
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run build --if-present
+        env:
+          CI: true

--- a/tests/utils/github-action-fixtures/already-has-cache/example1/expected.yml
+++ b/tests/utils/github-action-fixtures/already-has-cache/example1/expected.yml
@@ -1,0 +1,23 @@
+name: Build
+on:
+  push:
+    branches-ignore:
+      - main
+      - staging
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run build --if-present
+        env:
+          CI: true

--- a/tests/utils/github-action-fixtures/already-has-cache/example2/actual.yml
+++ b/tests/utils/github-action-fixtures/already-has-cache/example2/actual.yml
@@ -1,0 +1,23 @@
+name: Build
+on:
+  push:
+    branches-ignore:
+      - main
+      - staging
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run build --if-present
+        env:
+          CI: true

--- a/tests/utils/github-action-fixtures/already-has-cache/example2/expected.yml
+++ b/tests/utils/github-action-fixtures/already-has-cache/example2/expected.yml
@@ -1,0 +1,23 @@
+name: Build
+on:
+  push:
+    branches-ignore:
+      - main
+      - staging
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run build --if-present
+        env:
+          CI: true

--- a/tests/utils/github-action-fixtures/pending-to-add-cache/example1/actual.yml
+++ b/tests/utils/github-action-fixtures/pending-to-add-cache/example1/actual.yml
@@ -1,0 +1,35 @@
+name: Test
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+jobs:
+  main:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        node-version: [10.x, 12.x, 14.x, 15.x]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Cache node_modules
+        id: cache-node_modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node_modules-${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
+
+      - name: npm ci
+        if: steps.cache-node_modules.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Jest
+        run: npx --no-install jest
+      - name: CLI sanity
+        run: npm run test:cli-sanity
+      - name: CLI sanity warning
+        run: npm run test:cli-sanity-warning

--- a/tests/utils/github-action-fixtures/pending-to-add-cache/example1/expected.yml
+++ b/tests/utils/github-action-fixtures/pending-to-add-cache/example1/expected.yml
@@ -1,0 +1,36 @@
+name: Test
+on:
+  push:
+    branches:
+      - "main"
+  pull_request: null
+jobs:
+  main:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        node-version: [10.x, 12.x, 14.x, 15.x]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Cache node_modules
+        id: cache-node_modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node_modules-${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
+
+      - name: npm ci
+        if: steps.cache-node_modules.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Jest
+        run: npx --no-install jest
+      - name: CLI sanity
+        run: npm run test:cli-sanity
+      - name: CLI sanity warning
+        run: npm run test:cli-sanity-warning

--- a/tests/utils/github-action-fixtures/pending-to-add-cache/example2/actual.yml
+++ b/tests/utils/github-action-fixtures/pending-to-add-cache/example2/actual.yml
@@ -1,0 +1,35 @@
+name: Test
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+jobs:
+  main:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        node-version: [10.x, 12.x, 14.x, 15.x]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Cache node_modules
+        id: cache-node_modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node_modules-${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
+
+      - name: npm ci
+        if: steps.cache-node_modules.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Jest
+        run: npx --no-install jest
+      - name: CLI sanity
+        run: npm run test:cli-sanity
+      - name: CLI sanity warning
+        run: npm run test:cli-sanity-warning

--- a/tests/utils/github-action-fixtures/pending-to-add-cache/example2/expected.yml
+++ b/tests/utils/github-action-fixtures/pending-to-add-cache/example2/expected.yml
@@ -1,0 +1,36 @@
+name: Test
+on:
+  push:
+    branches:
+      - "main"
+  pull_request: null
+jobs:
+  main:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        node-version: [10.x, 12.x, 14.x, 15.x]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Cache node_modules
+        id: cache-node_modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: node_modules-${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('package-lock.json') }}
+
+      - name: npm ci
+        if: steps.cache-node_modules.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Jest
+        run: npx --no-install jest
+      - name: CLI sanity
+        run: npm run test:cli-sanity
+      - name: CLI sanity warning
+        run: npm run test:cli-sanity-warning

--- a/tests/utils/github-action-fixtures/pending-to-add-cache/example3/actual.yml
+++ b/tests/utils/github-action-fixtures/pending-to-add-cache/example3/actual.yml
@@ -1,0 +1,21 @@
+name: Test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+      - name: Install
+        run: npm ci
+      - name: Check JS
+        run: npx -p typescript tsc --allowJs --noEmit --lib es2020 *.js
+      - name: Test
+        run: npm test

--- a/tests/utils/github-action-fixtures/pending-to-add-cache/example3/expected.yml
+++ b/tests/utils/github-action-fixtures/pending-to-add-cache/example3/expected.yml
@@ -1,0 +1,22 @@
+name: Test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: npm
+      - name: Install
+        run: npm ci
+      - name: Check JS
+        run: npx -p typescript tsc --allowJs --noEmit --lib es2020 *.js
+      - name: Test
+        run: npm test

--- a/tests/utils/github-action-fixtures/pending-to-add-cache/example4/actual.yml
+++ b/tests/utils/github-action-fixtures/pending-to-add-cache/example4/actual.yml
@@ -1,0 +1,19 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "12.x"
+      - run: npm ci
+      - run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}

--- a/tests/utils/github-action-fixtures/pending-to-add-cache/example4/expected.yml
+++ b/tests/utils/github-action-fixtures/pending-to-add-cache/example4/expected.yml
@@ -1,0 +1,20 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "12.x"
+          cache: npm
+      - run: npm ci
+      - run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}

--- a/tests/utils/github-action-fixtures/pending-to-add-cache/example5/actual.yml
+++ b/tests/utils/github-action-fixtures/pending-to-add-cache/example5/actual.yml
@@ -1,0 +1,21 @@
+name: Node.js CI
+'on':
+  push:
+    branches:
+      - master
+      - "dependabot/**"
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - uses: bahmutov/npm-install@v1
+      - run: npm test

--- a/tests/utils/github-action-fixtures/pending-to-add-cache/example5/expected.yml
+++ b/tests/utils/github-action-fixtures/pending-to-add-cache/example5/expected.yml
@@ -1,0 +1,22 @@
+name: Node.js CI
+"on":
+  push:
+    branches:
+      - master
+      - "dependabot/**"
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: npm
+      - uses: bahmutov/npm-install@v1
+      - run: npm test

--- a/tests/utils/yaml-parser.test.js
+++ b/tests/utils/yaml-parser.test.js
@@ -1,0 +1,62 @@
+import { test, suite } from "uvu";
+import * as assert from "uvu/assert";
+import { getAddCacheToSetupNodeFunction } from "../../utils/yaml-parser.js";
+import fs from "fs";
+
+const getDirs = (source) =>
+  fs
+    .readdirSync(source, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory());
+
+const pendingCacheFixturesPath =
+  "./tests/utils/github-action-fixtures/pending-to-add-cache";
+const cacheSuite = suite("Add cache step with 'npm'");
+const cachePendingToAddExamples = getDirs(pendingCacheFixturesPath);
+
+for (const example of cachePendingToAddExamples) {
+  cacheSuite(`for ${example.name}`, () => {
+    const actualFileContent = fs.readFileSync(
+      `${pendingCacheFixturesPath}/${example.name}/actual.yml`,
+      { encoding: "utf8", flag: "r" }
+    );
+
+    const expectedFileContent = fs.readFileSync(
+      `${pendingCacheFixturesPath}/${example.name}/expected.yml`,
+      { encoding: "utf8", flag: "r" }
+    );
+
+    assert.is(
+      getAddCacheToSetupNodeFunction("npm")({
+        content: actualFileContent,
+        encoding: "utf-8",
+      }),
+      expectedFileContent
+    );
+  });
+}
+
+cacheSuite.run();
+
+const hasCacheFixturesPath =
+  "./tests/utils/github-action-fixtures/already-has-cache";
+const cacheSuiteAlreadySet = suite("Cache step is already added");
+const cacheAlreadySetExamples = getDirs(hasCacheFixturesPath);
+
+for (const example of cacheAlreadySetExamples) {
+  cacheSuiteAlreadySet(`for ${example.name}`, () => {
+    const actualFileContent = fs.readFileSync(
+      `${hasCacheFixturesPath}/${example.name}/actual.yml`,
+      { encoding: "utf8", flag: "r" }
+    );
+
+    assert.is(
+      getAddCacheToSetupNodeFunction("npm")({
+        content: actualFileContent,
+        encoding: "utf-8",
+      }),
+      null
+    );
+  });
+}
+
+cacheSuiteAlreadySet.run();

--- a/utils/yaml-parser.js
+++ b/utils/yaml-parser.js
@@ -1,0 +1,59 @@
+import YAML from "yaml";
+import prettier from "prettier";
+
+const { parseDocument } = YAML;
+
+/**
+ * @param {string} cache
+ *
+ * @return {function}
+ */
+
+export function getAddCacheToSetupNodeFunction(cache) {
+  /**
+   * Adds 'cache' option to 'setup-node' step of a GitHub Action
+   * @param {object} options
+   * @param {string} [options.content] File content of the GitHub Action
+   * @param {string} [options.encoding] Encoding to use to get the stringified content of the GitHub Action
+   *
+   * @return {?string} Returns the content of the GitHub Action file  with 'cache' option added or null if the file was not modified
+   */
+  return function addCacheToSetupNodeStep({ content, encoding }) {
+    const yamlDocument = parseDocument(
+      Buffer.from(content, encoding).toString("utf-8")
+    );
+    const jobs = yamlDocument.get("jobs");
+    let cacheAdded = false;
+
+    for (const { value: job } of jobs.items) {
+      const steps = job.get("steps");
+      for (const step of steps.items) {
+        const stepUses = step.get("uses");
+        const stepWith = step.get("with");
+
+        if (
+          stepUses &&
+          stepUses.includes("actions/setup-node") &&
+          (!stepWith || !stepWith.get("cache"))
+        ) {
+          if (!stepWith) {
+            step.set("with", { cache });
+          } else {
+            stepWith.set("cache", cache);
+          }
+
+          if (stepUses === "actions/setup-node@v1") {
+            step.set("uses", "actions/setup-node@v2");
+          }
+
+          cacheAdded = true;
+        }
+      }
+    }
+
+    return cacheAdded ? prettier.format(
+		yamlDocument.toString({lineWidth: 0}), {
+			parser: 'yaml'
+		}) : null;
+  };
+}


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
- Extract `function` to parse and change the yaml files into its own file for testing purposes
- Installed `uvu` for testing
- Added basic test suites to assure the parse function:
   - It modifies the file when there's `setup-node` step without `cache` option
   - It bumps to `setup-node` to `v2` if it is not already bumped
   - It does not modify the file if no step contains `setup-node`
   - It does not modify the file if `setup-node` has `cache` option already
 
## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To control all the possible use-cases before running the script to a GitHub Organization