### PR TITLE
Add support for gh actions using `bahmutov/npm-install`

### DIFF
--- a/tests/utils/github-action-fixtures/already-has-cache/not-replace-bahmutov-npm-install/actual.yml
+++ b/tests/utils/github-action-fixtures/already-has-cache/not-replace-bahmutov-npm-install/actual.yml
@@ -1,0 +1,16 @@
+name: Node.js CI
+"on":
+  push:
+    branches:
+      - master
+      - "dependabot/**"
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bahmutov/npm-install@v1
+      - run: npm test

--- a/tests/utils/github-action-fixtures/already-has-cache/not-replace-bahmutov-npm-install/expected.yml
+++ b/tests/utils/github-action-fixtures/already-has-cache/not-replace-bahmutov-npm-install/expected.yml
@@ -1,0 +1,16 @@
+name: Node.js CI
+"on":
+  push:
+    branches:
+      - master
+      - "dependabot/**"
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bahmutov/npm-install@v1
+      - run: npm test

--- a/tests/utils/github-action-fixtures/pending-to-add-cache/replace-bahmutov-npm-install/actual.yml
+++ b/tests/utils/github-action-fixtures/pending-to-add-cache/replace-bahmutov-npm-install/actual.yml
@@ -14,9 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v1
         with:
           node-version: 12.x
-          cache: npm
       - uses: bahmutov/npm-install@v1
       - run: npm test

--- a/tests/utils/github-action-fixtures/pending-to-add-cache/replace-bahmutov-npm-install/expected.yml
+++ b/tests/utils/github-action-fixtures/pending-to-add-cache/replace-bahmutov-npm-install/expected.yml
@@ -1,5 +1,5 @@
 name: Node.js CI
-'on':
+"on":
   push:
     branches:
       - master
@@ -14,8 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 12.x
-      - uses: bahmutov/npm-install@v1
+          cache: npm
+      - run: npm ci
       - run: npm test


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
- Cover use case of GitHub Actions using `bahmutov/npm-install` as method of caching npm dependencies in GH Actions

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix #13 