### PR TITLE
fix(script): add explicit extension when importing yaml-parser

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { composeCreatePullRequest } from "octokit-plugin-create-pull-request";
-import { getAddCacheToSetupNodeFunction } from "./utils/yaml-parser";
+import { getAddCacheToSetupNodeFunction } from "./utils/yaml-parser.js";
 
 const BRANCH_NAME = "add-cache-to-node-workflows";
 const PATH = ".github/workflows";


### PR DESCRIPTION
## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/XXXX/.npm/_npx/84938/lib/node_modules/octoherd-script-add-cache-to-node-github-action/utils/yaml-parser' imported from /Users/XXXXX/.npm/_npx/84938/lib/node_modules/octoherd-script-add-cache-to-node-github-action/script.js
Did you mean to import ../../../../../../../dev/open-source/octoherd/octoherd-script-add-cache-to-node-github-action/utils/yaml-parser.js?
```